### PR TITLE
Fix teleporters and overlapping buttons

### DIFF
--- a/interface/sip/sip.config
+++ b/interface/sip/sip.config
@@ -640,8 +640,8 @@
 							"baseImageChecked": "/interface/sip/categories/otherselected.png",
 							"hoverImageChecked": "/interface/sip/categories/otherselected.png?brightness=30",
 							"pressedOffset": [0, -1],
-							"position": [112, -347],
-							"data": ["other", "generic", "teleportmarker"]
+							"position": [112, -372],
+							"data": ["other", "generic", "teleportmarker", "teleporter"]
 						},
 						{
 							"baseImage": "/interface/sip/categories/platforms.png",


### PR DESCRIPTION
The Light and Misc Objects buttons are in the same space, so I've moved the latter down one row. I also added `teleporter` to its list of filters, since teleporters don't show in any category