### PR TITLE
Vanilla and oSB fixes

### DIFF
--- a/interface/sip/categories.config
+++ b/interface/sip/categories.config
@@ -1,5 +1,9 @@
 // This is structured slightly differently from how SIP mods do their
 // categories because we want the order not to be randomized.
+
+// The 'fuel' category is intentionally omitted because it is the
+// only vanilla category to have members of multiple item types.
+// (Generic item erchius fuel, and liquid item erchius fuel)
 [{
     "Vanity:": [{
         "image": "/interface/sip/categories/vanityhat.png",
@@ -129,7 +133,7 @@
         "image": "/interface/sip/categories/matitems.png",
         "selectedImage": "/interface/sip/categories/matitemsselected.png",
         "categories": [
-          "blocks", "block", "materials", "liqitem", "supports", "railpoint", "matitem"
+          "blocks", "block", "materials", "liqitem", "supports", "railpoint", "matitem", "rail"
         ]
       }, {
         "image": "/interface/sip/categories/platforms.png",
@@ -188,7 +192,7 @@
       }, {
         "image": "/interface/sip/categories/other.png",
         "selectedImage": "/interface/sip/categories/otherselected.png",
-        "categories": ["other", "generic", "teleportmarker", "teleporter", "object"]
+        "categories": ["other", "generic", "teleportmarker", "teleporter", "object", "techmanagement"]
       }
     ]
   }


### PR DESCRIPTION
Vanilla: Add missing 'rail' and 'techManagement' items to existing categories (blocks and misc objects)

oSB:
* Check if the inventory icon is set to an empty table (should fix https://github.com/Silverfeelin/Starbound-SpawnableItemPack/issues/47)
* pcall item loads (don't load broken items that Starbound doesn't catch)
* Commented-out debug "Are there any vanilla categories missing?" functionality in sip_postload.lua